### PR TITLE
Fix code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/iwtcms_ssl_client.py
+++ b/iwtcms_ssl_client.py
@@ -28,7 +28,7 @@ def main():
     client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     context = ssl.create_default_context()
-
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.check_hostname = False  # ! IMPORTANT disable check for "handmade" certs
     context.verify_mode = ssl.CERT_NONE  # ! IMPORTANT disable check for "handmade" certs
 


### PR DESCRIPTION
Fixes [https://github.com/Bumer-32/I-Want-To-Control-My-Server/security/code-scanning/1](https://github.com/Bumer-32/I-Want-To-Control-My-Server/security/code-scanning/1)

To fix the problem, we need to ensure that the SSL/TLS context created by `ssl.create_default_context()` only allows TLSv1.2 or higher. This can be done by setting the `minimum_version` attribute of the SSL context to `ssl.TLSVersion.TLSv1_2`. This change ensures that the context will not use any insecure versions of SSL/TLS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
